### PR TITLE
Debugging cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+dsk2nib
+dsk2nib.o
+nib2dsk
+nib2dsk.o

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,8 @@
+include Makefile
+
+debug: clean
+debug: CFLAGS += -DDEBUG=1
+debug: CFLAGS += -g
+debug: CFLAGS += -fsanitize=address
+debug: LDLIBS += -lasan
+debug: all

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Apple II DSK-to-NIB and NIB-to-DSK image file conversion utilities.
 
 Build
 -----
-Run `make clean all` to produce the `dsk2nib` and `nib2dsk` executables.
+Run `make clean all` to produce the `dsk2nib` and `nib2dsk`
+executables. Use `make debug` to create debugging binaries, if desired.
+
 
 Sample Usage
 ------------
@@ -11,6 +13,10 @@ Some Apple II games use the disk volume number to represent the disk number in a
 
     dsk2nib shadowkeep4.dsk shadowkeep4.nib 4
     nib2dsk silicon.nib silicon.dsk
+
+Note
+----
+All DSK files can be turned into NIBs, but not vice-versa. 
 
 History
 -------


### PR DESCRIPTION
Disabling debugging (`myprintf`) by default (nib2dsk was printing a number for every single byte read). 

Allow `make debug` to create debugging binaries if desired. (Currently only if using GNU make as I'm not sure if my syntax will work on BSD make). 
    
Other changes in nib2dsk:
    
  * ueof (unexpected end of file) is now a function that prints out
      which state the FSM was in when it ran out of data.
    
  * Print debugging info if the data prolog does not match.
    
  * The: debug info that prints each byte index now overwrites the
      previous one (instead of appending) if nothing interesting happened.

  * Bumped version to 1.1
    
